### PR TITLE
Fix minor typo

### DIFF
--- a/_posts/2020-09-03-org-babel.md
+++ b/_posts/2020-09-03-org-babel.md
@@ -66,5 +66,5 @@ use multiple `*` for subheadings (e.g. `**` etc)
 
 - tangle: can be used for literate programming.
 - emacs configuration as an org-mode file.
-    - `org-bable-tangle` extracts all the code from an org mode that then it can be used (e.g., by emacs to use to load the configuration file).
-    - `(org-bable-load-file "file")` it's a org-bable helper function that will untangle the org-mode file when load.
+    - `org-babel-tangle` extracts all the code from an org mode that then it can be used (e.g., by emacs to use to load the configuration file).
+    - `(org-babel-load-file "file")` it's a org-bable helper function that will untangle the org-mode file when load.


### PR DESCRIPTION
"bable" → "babel"